### PR TITLE
create_loc_conf must return NULL on error

### DIFF
--- a/src/ngx_http_echo_module.c
+++ b/src/ngx_http_echo_module.c
@@ -247,7 +247,7 @@ ngx_http_echo_create_loc_conf(ngx_conf_t *cf)
 
     conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_echo_loc_conf_t));
     if (conf == NULL) {
-        return NGX_CONF_ERROR;
+        return NULL;
     }
 
     /* set by ngx_pcalloc


### PR DESCRIPTION
All create_(main|srv|loc|*)_conf methods must return NULL on error, not NGX_CONF_ERROR.

See nginx revision:

changeset:   2912:c7d57b539248
user:        Igor Sysoev igor@sysoev.ru
date:        Tue Jun 02 16:09:44 2009 +0000
summary:     return NULL instead of NGX_CONF_ERROR on a create conf failure

And also see ngx_http_core_server at src/http/ngx_http_core_module.c around 2985 and 2996. If value is not NULL, conf is accepted and causes errors later.
