### PR TITLE
Fix issue with subrequests being out of order

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,7 +50,6 @@ Table of Contents
     * [$echo_response_status](#echo_response_status)
 * [Installation](#installation)
 * [Compatibility](#compatibility)
-* [Known Issues](#known-issues)
 * [Modules that use this module for testing](#modules-that-use-this-module-for-testing)
 * [Community](#community)
     * [English Mailing List](#english-mailing-list)
@@ -846,8 +845,6 @@ is logically equivalent to
 
 But calling this directive is slightly faster than calling [echo_subrequest_async](#echo_subrequest_async) using `GET` because we don't have to parse the HTTP method names like `GET` and options like `-q`.
 
-There is a known issue with this directive when disabling the standard [standard SSI module](http://nginx.org/en/docs/http/ngx_http_ssi_module.html). See [Known Issues](#known-issues) for more details.
-
 This directive is first introduced in [version 0.09](#v009) of this module and requires at least Nginx 0.7.46.
 
 [Back to TOC](#table-of-contents)
@@ -1025,8 +1022,6 @@ This directive was first introduced in the [release v0.15](#v015).
 The `-f` option to define a file path for the body was introduced in the [release v0.35](#v035).
 
 See also the [echo_subrequest](#echo_subrequest) and [echo_location_async](#echo_location_async) directives.
-
-There is a known issue with this directive when disabling the standard [standard SSI module](http://nginx.org/en/docs/http/ngx_http_ssi_module.html). See [Known Issues](#known-issues) for more details.
 
 [Back to TOC](#table-of-contents)
 
@@ -1623,20 +1618,6 @@ In particular,
 Earlier versions of Nginx like 0.6.x and 0.5.x will *not* work at all.
 
 If you find that any particular version of Nginx above 0.7.21 does not work with this module, please consider [reporting a bug](#report-bugs).
-
-[Back to TOC](#table-of-contents)
-
-Known Issues
-============
-
-Due to an unknown bug in Nginx (it still exists in Nginx 1.7.7), the [standard SSI module](http://nginx.org/en/docs/http/ngx_http_ssi_module.html) is required to ensure that the contents of the subrequests issued by [echo_locatoin_async](#echo_location_async) and [echo_subrequest_async](#echo_subrequest_async) are correctly merged into the output chains of the main one. Fortunately, the SSI module is enabled by default during Nginx's `configure` process.
-
-If calling this directive without SSI module enabled, you'll get truncated response without contents of any subrequests and get an alert message in your Nginx's `error.log`, like this:
-
-```nginx
-
-   [alert] 24212#0: *1 the http output chain is empty, client: 127.0.0.1, ...
-```
 
 [Back to TOC](#table-of-contents)
 

--- a/config
+++ b/config
@@ -3,3 +3,8 @@ HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_echo_module"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_echo_module.c $ngx_addon_dir/src/ngx_http_echo_util.c $ngx_addon_dir/src/ngx_http_echo_timer.c $ngx_addon_dir/src/ngx_http_echo_var.c $ngx_addon_dir/src/ngx_http_echo_handler.c $ngx_addon_dir/src/ngx_http_echo_filter.c $ngx_addon_dir/src/ngx_http_echo_sleep.c $ngx_addon_dir/src/ngx_http_echo_location.c $ngx_addon_dir/src/ngx_http_echo_echo.c $ngx_addon_dir/src/ngx_http_echo_request_info.c $ngx_addon_dir/src/ngx_http_echo_subrequest.c $ngx_addon_dir/src/ngx_http_echo_foreach.c"
 NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/src/ngx_http_echo_module.h $ngx_addon_dir/src/ddebug.h $ngx_addon_dir/src/ngx_http_echo_handler.h $ngx_addon_dir/src/ngx_http_echo_util.h $ngx_addon_dir/src/ngx_http_echo_sleep.h $ngx_addon_dir/src/ngx_http_echo_filter.h $ngx_addon_dir/src/ngx_http_echo_var.h $ngx_addon_dir/src/ngx_http_echo_location.h $ngx_addon_dir/src/ngx_http_echo_echo.h $ngx_addon_dir/src/ngx_http_echo_request_info.h $ngx_addon_dir/src/ngx_http_echo_subrequest.h $ngx_addon_dir/src/ngx_http_echo_foreach.h"
 
+# This module depends upon the postpone filter being activated
+if [ $HTTP_POSTPONE != YES ]; then
+    HTTP_FILTER_MODULES="$HTTP_FILTER_MODULES $HTTP_POSTPONE_FILTER_MODULE"
+    HTTP_SRCS="$HTTP_SRCS $HTTP_POSTPONE_FILTER_SRCS"
+fi


### PR DESCRIPTION
This fixes an issues where subrequests wouldn't have their order preserved and
the output chain would be mangled. It was assumed this related to the SSI module
which has dependency on the postpone filter and was including it in affected cases.

By making this dependency explicit, we no longer require the SSI module for this
to work.

--------

**Full disclosure:** I do not use this module myself and have not performed extensive testing of this change.