### PR TITLE
Require SSI & friends to pull in postpone

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1589,6 +1589,11 @@ Starting from NGINX 1.9.11, you can also compile this module as a dynamic module
 `./configure` command line above. And then you can explicitly load the module in your `nginx.conf` via the [load_module](http://nginx.org/en/docs/ngx_core_module.html#load_module)
 directive, for example,
 
+This module also depends on the ngx_http_postpone_filter_module, which cannot be enabled directly. You must ensure at least one of the built-in nginx modules which depends upon
+the postpone module is enabled to pull in that dependency. As of version 1.9 that means you must enable one of the http_ssi, http_slice or http_addition modules.
+
+Those include: ngx_http_ssi_module,, ngx_http_slice_module, 
+
 ```nginx
 load_module /path/to/modules/ngx_http_echo_module.so;
 ```

--- a/config
+++ b/config
@@ -30,12 +30,6 @@ ECHO_DEPS="                                                                 \
         $ngx_addon_dir/src/ngx_http_echo_foreach.h                          \
         "
 
-# This module depends upon the postpone filter being activated
-if [ $HTTP_POSTPONE != YES ]; then
-    HTTP_FILTER_MODULES="$HTTP_FILTER_MODULES $HTTP_POSTPONE_FILTER_MODULE"
-    HTTP_SRCS="$HTTP_SRCS $HTTP_POSTPONE_FILTER_SRCS"
-fi
-
 if test -n "$ngx_module_link"; then
     ngx_module_type=HTTP_AUX_FILTER
     ngx_module_name=$ngx_addon_name


### PR DESCRIPTION
The upstream has expressed that they don't feel this is a flaw in
their build system since ssi is enabled by default (pulling in
postpone).

Rather than pile more hacks on the pile, we're going to throw in
the towel and just document the limitation under the installation
section of the README.

Closes #42
Reference: http://mailman.nginx.org/pipermail/nginx-devel/2016-April/008172.html