### PR TITLE
src/ngx_http_echo_subrequest.c: fix minor issue found by Coverity

### DIFF
--- a/src/ngx_http_echo_subrequest.c
+++ b/src/ngx_http_echo_subrequest.c
@@ -640,7 +640,7 @@ ngx_http_echo_exec_exec(ngx_http_request_t *r,
     ngx_str_t                       *uri;
     ngx_str_t                       *user_args;
     ngx_str_t                        args;
-    ngx_uint_t                       flags;
+    ngx_uint_t                       flags = 0;
     ngx_str_t                       *computed_arg;
 
     computed_arg = computed_args->elts;


### PR DESCRIPTION
```
661    args.data = NULL;
662    args.len = 0;
663
   CID 149849 (#1 of 1): Uninitialized scalar variable (UNINIT)5. uninit_use_in_call: Using uninitialized value flags when calling ngx_http_parse_unsafe_uri. [show details]
664    if (ngx_http_parse_unsafe_uri(r, uri, &args, &flags) != NGX_OK) {
665        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
666                       "echo_exec sees unsafe uri: \"%V\"",
667                       uri);
668        return NGX_ERROR;
669    }
```