### PR TITLE
fix potential null pointer dereference found by coverity

### DIFF
--- a/src/ngx_http_echo_location.c
+++ b/src/ngx_http_echo_location.c
@@ -89,6 +89,10 @@ ngx_http_echo_exec_echo_location(ngx_http_request_t *r,
     ngx_uint_t                           flags = 0;
     ngx_http_echo_ctx_t                 *sr_ctx;
 
+    if (computed_args == NULL) {
+        return NGX_ERROR;
+    }
+
     computed_arg_elts = computed_args->elts;
 
     location = computed_arg_elts[0];


### PR DESCRIPTION
```
   CID 258040 (#9 of 9): Explicit null dereferenced (FORWARD_NULL)9. var_deref_model: Passing null pointer computed_args to ngx_http_echo_exec_echo_location, which dereferences it. [show details]
259            return ngx_http_echo_exec_echo_location(r, ctx, computed_args);
```