### PR TITLE
fix potential null pointer dereference found by Coverity

### DIFF
--- a/src/ngx_http_echo_handler.c
+++ b/src/ngx_http_echo_handler.c
@@ -213,6 +213,10 @@ ngx_http_echo_run_cmds(ngx_http_request_t *r)
             }
         }
 
+        if (computed_args == NULL) {
+            return NGX_HTTP_INTERNAL_SERVER_ERROR;
+        }
+
         /* do command dispatch based on the opcode */
 
         switch (cmd->opcode) {


### PR DESCRIPTION
```
245            dd("found opcode echo location async...");
   CID 258040 (#8 of 8): Explicit null dereferenced (FORWARD_NULL)9. var_deref_model: Passing null pointer computed_args to ngx_http_echo_exec_echo_location_async, which dereferences it. [show details]
246            rc = ngx_http_echo_exec_echo_location_async(r, ctx,
247                                                        computed_args);
248            break;
```