### PR TITLE
Fix compatibility with freenginx

### DIFF
--- a/src/ngx_http_echo_module.h
+++ b/src/ngx_http_echo_module.h
@@ -123,7 +123,11 @@ typedef struct {
 
     ngx_http_echo_foreach_ctx_t   *foreach;
 
+#if (defined freenginx && nginx_version >= 1029000)
+    ngx_msec_t       timer_begin;
+#else
     ngx_time_t       timer_begin;
+#endif
 
     ngx_event_t      sleep;
 


### PR DESCRIPTION
Commit freenginx/nginx@3329aa9 replaced two fields start_sec and start_msec in the ngx_http_request_t structure with one field start_time.